### PR TITLE
[enh] Set lua-bitop as a dependency for WS support.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,8 +17,9 @@ Depends: adduser, ssl-cert, lua5.1,
  lua-socket,
  lua-sec,
  lua-filesystem (>= 1.4.2-3~),
+ lua-bitop,
  ${shlibs:Depends}, ${misc:Depends}
-Recommends: lua-zlib, lua-bitop
+Recommends: lua-zlib
 Suggests: lua-dbi-postgresql, lua-dbi-mysql, lua-dbi-sqlite3
 Provides: metronome-xmpp-server, metronome
 Conflicts: prosody-xmpp-server, prosody


### PR DESCRIPTION
Metronome is missing `lua-bitop` dependency to have websocket support to work.
Otherwise, we get that:
```bash
Oct 17 19:24:11 modulemanager	error	Error initializing module 'websocket' on 'silkaj.duniter.org': /usr/bin/metronome:149: loop or previous error loading module 'util.websocket'
stack traceback:
	/usr/lib/metronome/core/modulemanager.lua:30: in function </usr/lib/metronome/core/modulemanager.lua:30>
	[C]: in function '_real_require'
	/usr/bin/metronome:149: in function 'require'
	/usr/lib/metronome/modules/mod_websocket.lua:20: in main chunk
	(tail call): ?
	[C]: in function 'xpcall'
	/usr/lib/metronome/core/modulemanager.lua:30: in function 'pcall'
	/usr/lib/metronome/core/modulemanager.lua:163: in function 'do_load_module'
	/usr/lib/metronome/core/modulemanager.lua:240: in function 'load'
	/usr/lib/metronome/core/modulemanager.lua:61: in function '?'
	/usr/lib/metronome/util/events.lua:67: in function 'fire_event'
	/usr/lib/metronome/core/hostmanager.lua:119: in function 'activate'
	/usr/lib/metronome/core/hostmanager.lua:51: in function '?'
	/usr/lib/metronome/util/events.lua:67: in function 'fire_event'
	/usr/bin/metronome:288: in function 'prepare_to_start'
	/usr/bin/metronome:384: in main chunk
	[C]: ?
```